### PR TITLE
Configurable calcite transpose rule in PROJECT_REWRITE phase

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -407,15 +407,9 @@ public class OptimizerConfigOptions {
                             .enumType(ProjectFilterTransposeRule.class)
                             .defaultValue(ProjectFilterTransposeRule.PROJECT_FILTER_TRANSPOSE)
                             .withDescription(
-                                    "Selects which Calcite ProjectFilterTransposeRule variant the optimizer uses "
-                                            + "when pushing a Project past a Filter. "
-                                            + "PROJECT_FILTER_TRANSPOSE (default) splits Project expressions so only "
-                                            + "the columns referenced by the Filter remain below it. "
-                                            + "PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS preserves each top-level "
-                                            + "Project expression as a whole when pushing past the Filter. "
-                                            + "PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS treats the Project "
-                                            + "as atomic and only pushes it when the entire Project can move below "
-                                            + "the Filter - Required for nested projection pushdown + filters.");
+                                    "Selects which Calcite ProjectFilterTransposeRule variant the optimizer "
+                                            + "uses when pushing a Project past a Filter in the "
+                                            + "PROJECT_REWRITE phase.");
 
     /** Strategy for handling non-deterministic updates. */
     @PublicEvolving
@@ -527,7 +521,8 @@ public class OptimizerConfigOptions {
                 text(
                         "Pushes the Project past the Filter without splitting expressions. "
                                 + "Each top-level Project expression is preserved as a whole and "
-                                + "either pushed below the Filter or kept above it.")),
+                                + "either pushed below the Filter or kept above it."
+                                + "NOTE: Required for proper nested projection + filtering")),
         PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS(
                 text(
                         "Pushes the Project past the Filter only when the Project as a whole can be "

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -400,6 +400,23 @@ public class OptimizerConfigOptions {
                     .withDescription(
                             "Strategy for optimizing the delta-join. Only AUTO, FORCE or NONE can be set. Default it AUTO.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<ProjectFilterTransposeRule>
+            TABLE_OPTIMIZER_PROJECT_FILTER_TRANSPOSE_RULE =
+                    key("table.optimizer.project-filter-transpose-rule")
+                            .enumType(ProjectFilterTransposeRule.class)
+                            .defaultValue(ProjectFilterTransposeRule.PROJECT_FILTER_TRANSPOSE)
+                            .withDescription(
+                                    "Selects which Calcite ProjectFilterTransposeRule variant the optimizer uses "
+                                            + "when pushing a Project past a Filter. "
+                                            + "PROJECT_FILTER_TRANSPOSE (default) splits Project expressions so only "
+                                            + "the columns referenced by the Filter remain below it. "
+                                            + "PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS preserves each top-level "
+                                            + "Project expression as a whole when pushing past the Filter. "
+                                            + "PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS treats the Project "
+                                            + "as atomic and only pushes it when the entire Project can move below "
+                                            + "the Filter - Required for nested projection pushdown + filters.");
+
     /** Strategy for handling non-deterministic updates. */
     @PublicEvolving
     public enum NonDeterministicUpdateStrategy {
@@ -488,6 +505,38 @@ public class OptimizerConfigOptions {
         private final InlineElement description;
 
         DeltaJoinStrategy(InlineElement description) {
+            this.description = description;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
+    }
+
+    /**
+     * Variant of Calcite's ProjectFilterTransposeRule used when pushing a Project past a Filter.
+     */
+    @PublicEvolving
+    public enum ProjectFilterTransposeRule implements DescribedEnum {
+        PROJECT_FILTER_TRANSPOSE(
+                text(
+                        "Default variant. Pushes a Project past a Filter, splitting expressions "
+                                + "so that only the columns referenced by the Filter remain below it.")),
+        PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS(
+                text(
+                        "Pushes the Project past the Filter without splitting expressions. "
+                                + "Each top-level Project expression is preserved as a whole and "
+                                + "either pushed below the Filter or kept above it.")),
+        PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS(
+                text(
+                        "Pushes the Project past the Filter only when the Project as a whole can be "
+                                + "moved below the Filter; the Project is treated as atomic and is "
+                                + "never split."));
+
+        private final InlineElement description;
+
+        ProjectFilterTransposeRule(InlineElement description) {
             this.description = description;
         }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -22,7 +22,12 @@ import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.rules.FlinkBatchRuleSets
 
+import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.rel.rules.CoreRules
+import org.apache.calcite.tools.{RuleSet, RuleSets}
+
+import scala.collection.JavaConverters._
 
 /** Defines a sequence of programs to optimize flink batch table plan. */
 object FlinkBatchProgram {
@@ -45,6 +50,7 @@ object FlinkBatchProgram {
 
   def buildProgram(tableConfig: ReadableConfig): FlinkChainedProgram[BatchOptimizeContext] = {
     val chainedProgram = new FlinkChainedProgram[BatchOptimizeContext]()
+    val projectFilterTransposeRule = pickProjectFilterTransposeRule(tableConfig)
 
     chainedProgram.addLast(
       // rewrite sub-queries to joins
@@ -240,16 +246,26 @@ object FlinkBatchProgram {
     )
 
     // window rewrite
+    // PROJECT_RULES carries CoreRules.PROJECT_FILTER_TRANSPOSE as the safe default for Volcano;
+    // here in HEP we swap it for the configured variant.
     chainedProgram.addLast(
       PROJECT_REWRITE,
       FlinkHepRuleSetProgramBuilder.newBuilder
         .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-        .add(FlinkBatchRuleSets.PROJECT_RULES)
+        .add(
+          substituteRule(
+            FlinkBatchRuleSets.PROJECT_RULES,
+            CoreRules.PROJECT_FILTER_TRANSPOSE,
+            projectFilterTransposeRule))
         .build()
     )
 
     // optimize the logical plan
+    // Note: the project-filter-transpose variant is intentionally NOT appended to the Volcano
+    // LOGICAL phase. The HEP PROJECT_REWRITE phase above already pushes the transpose down, and
+    // adding WHOLE_EXPRESSIONS here oscillates with FlinkFilterProjectTransposeRule in
+    // FILTER_RULES (no bloat protection), expanding the MEMO indefinitely.
     chainedProgram.addLast(
       LOGICAL,
       FlinkVolcanoProgramBuilder.newBuilder
@@ -297,5 +313,24 @@ object FlinkBatchProgram {
     chainedProgram.addLast(RUNTIME_FILTER, new FlinkRuntimeFilterProgram)
 
     chainedProgram
+  }
+
+  private def pickProjectFilterTransposeRule(tableConfig: ReadableConfig): RelOptRule = {
+    tableConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_PROJECT_FILTER_TRANSPOSE_RULE) match {
+      case OptimizerConfigOptions.ProjectFilterTransposeRule.PROJECT_FILTER_TRANSPOSE =>
+        CoreRules.PROJECT_FILTER_TRANSPOSE
+      case OptimizerConfigOptions.ProjectFilterTransposeRule.PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS =>
+        CoreRules.PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS
+      case OptimizerConfigOptions.ProjectFilterTransposeRule.PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS =>
+        CoreRules.PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS
+    }
+  }
+
+  private def substituteRule(base: RuleSet, oldRule: RelOptRule, newRule: RelOptRule): RuleSet = {
+    if (oldRule eq newRule) {
+      base
+    } else {
+      RuleSets.ofList((base.asScala.filterNot(_ eq oldRule) ++ Seq(newRule)).asJava)
+    }
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -245,9 +245,7 @@ object FlinkBatchProgram {
         .build()
     )
 
-    // window rewrite
-    // PROJECT_RULES carries CoreRules.PROJECT_FILTER_TRANSPOSE as the safe default for Volcano;
-    // here in HEP we swap it for the configured variant.
+    // In PROJECT_REWRITE we utilize user desired transposition method
     chainedProgram.addLast(
       PROJECT_REWRITE,
       FlinkHepRuleSetProgramBuilder.newBuilder
@@ -263,9 +261,7 @@ object FlinkBatchProgram {
 
     // optimize the logical plan
     // Note: the project-filter-transpose variant is intentionally NOT appended to the Volcano
-    // LOGICAL phase. The HEP PROJECT_REWRITE phase above already pushes the transpose down, and
-    // adding WHOLE_EXPRESSIONS here oscillates with FlinkFilterProjectTransposeRule in
-    // FILTER_RULES (no bloat protection), expanding the MEMO indefinitely.
+    // LOGICAL phase. Prevents infinite oscillation with optimization from PROJECT_REWRITE
     chainedProgram.addLast(
       LOGICAL,
       FlinkVolcanoProgramBuilder.newBuilder

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -24,7 +24,12 @@ import org.apache.flink.table.planner.plan.rules.FlinkStreamRuleSets
 import org.apache.flink.table.planner.plan.rules.logical.EventTimeTemporalJoinRewriteRule
 import org.apache.flink.table.planner.plan.rules.physical.stream.{FlinkDuplicateChangesTraitInitProgram, FlinkMarkChangelogNormalizeProgram}
 
+import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.rel.rules.CoreRules
+import org.apache.calcite.tools.{RuleSet, RuleSets}
+
+import scala.collection.JavaConverters._
 
 /** Defines a sequence of programs to optimize for stream table plan. */
 object FlinkStreamProgram {
@@ -45,6 +50,7 @@ object FlinkStreamProgram {
 
   def buildProgram(tableConfig: ReadableConfig): FlinkChainedProgram[StreamOptimizeContext] = {
     val chainedProgram = new FlinkChainedProgram[StreamOptimizeContext]()
+    val projectFilterTransposeRule = pickProjectFilterTransposeRule(tableConfig)
 
     // rewrite sub-queries to joins
     chainedProgram.addLast(
@@ -248,17 +254,29 @@ object FlinkStreamProgram {
         .build()
     )
 
+    // TODO this pushing directly into rule set after the fact feels janky and not ideal
+    // find better way to do this
     // project rewrite
+    // PROJECT_RULES carries CoreRules.PROJECT_FILTER_TRANSPOSE as the safe default for Volcano;
+    // here in HEP we swap it for the configured variant.
     chainedProgram.addLast(
       PROJECT_REWRITE,
       FlinkHepRuleSetProgramBuilder.newBuilder
         .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-        .add(FlinkStreamRuleSets.PROJECT_RULES)
+        .add(
+          substituteRule(
+            FlinkStreamRuleSets.PROJECT_RULES,
+            CoreRules.PROJECT_FILTER_TRANSPOSE,
+            projectFilterTransposeRule))
         .build()
     )
 
     // optimize the logical plan
+    // Note: the project-filter-transpose variant is intentionally NOT appended to the Volcano
+    // LOGICAL phase. The HEP PROJECT_REWRITE phase above already pushes the transpose down, and
+    // adding WHOLE_EXPRESSIONS here oscillates with FlinkFilterProjectTransposeRule in
+    // FILTER_RULES (no bloat protection), expanding the MEMO indefinitely.
     chainedProgram.addLast(
       LOGICAL,
       FlinkVolcanoProgramBuilder.newBuilder
@@ -359,5 +377,24 @@ object FlinkStreamProgram {
     )
 
     chainedProgram
+  }
+
+  private def pickProjectFilterTransposeRule(tableConfig: ReadableConfig): RelOptRule = {
+    tableConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_PROJECT_FILTER_TRANSPOSE_RULE) match {
+      case OptimizerConfigOptions.ProjectFilterTransposeRule.PROJECT_FILTER_TRANSPOSE =>
+        CoreRules.PROJECT_FILTER_TRANSPOSE
+      case OptimizerConfigOptions.ProjectFilterTransposeRule.PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS =>
+        CoreRules.PROJECT_FILTER_TRANSPOSE_WHOLE_EXPRESSIONS
+      case OptimizerConfigOptions.ProjectFilterTransposeRule.PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS =>
+        CoreRules.PROJECT_FILTER_TRANSPOSE_WHOLE_PROJECT_EXPRESSIONS
+    }
+  }
+
+  private def substituteRule(base: RuleSet, oldRule: RelOptRule, newRule: RelOptRule): RuleSet = {
+    if (oldRule eq newRule) {
+      base
+    } else {
+      RuleSets.ofList((base.asScala.filterNot(_ eq oldRule) ++ Seq(newRule)).asJava)
+    }
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -254,11 +254,7 @@ object FlinkStreamProgram {
         .build()
     )
 
-    // TODO this pushing directly into rule set after the fact feels janky and not ideal
-    // find better way to do this
-    // project rewrite
-    // PROJECT_RULES carries CoreRules.PROJECT_FILTER_TRANSPOSE as the safe default for Volcano;
-    // here in HEP we swap it for the configured variant.
+    // In PROJECT_REWRITE we utilize user desired transposition method
     chainedProgram.addLast(
       PROJECT_REWRITE,
       FlinkHepRuleSetProgramBuilder.newBuilder
@@ -274,9 +270,7 @@ object FlinkStreamProgram {
 
     // optimize the logical plan
     // Note: the project-filter-transpose variant is intentionally NOT appended to the Volcano
-    // LOGICAL phase. The HEP PROJECT_REWRITE phase above already pushes the transpose down, and
-    // adding WHOLE_EXPRESSIONS here oscillates with FlinkFilterProjectTransposeRule in
-    // FILTER_RULES (no bloat protection), expanding the MEMO indefinitely.
+    // LOGICAL phase. Prevents infinite oscillation with optimization from PROJECT_REWRITE
     chainedProgram.addLast(
       LOGICAL,
       FlinkVolcanoProgramBuilder.newBuilder

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -204,9 +204,19 @@ object FlinkBatchRuleSets {
     CoreRules.AGGREGATE_VALUES
   )
 
-  /** RuleSet about project */
+  /**
+   * RuleSet about project.
+   *
+   * <p>Note: [[CoreRules.PROJECT_FILTER_TRANSPOSE]] is the safe default kept here so it propagates
+   * into [[LOGICAL_OPT_RULES]] for the Volcano LOGICAL phase. In the HEP `PROJECT_REWRITE` phase,
+   * [[FlinkBatchProgram.buildProgram]] substitutes the configured variant from
+   * [[OptimizerConfigOptions.TABLE_OPTIMIZER_PROJECT_FILTER_TRANSPOSE_RULE]]. The aggressive
+   * `WHOLE_EXPRESSIONS` variant must NOT reach Volcano — it oscillates with
+   * [[FlinkFilterProjectTransposeRule]] when bloat protection is bypassed. See
+   * PROJECT_FILTER_TRANSPOSE_HANG.md.
+   */
   val PROJECT_RULES: RuleSet = RuleSets.ofList(
-    // push a projection past a filter
+    // push a projection past a filter (safe default; HEP swaps in the configured variant)
     CoreRules.PROJECT_FILTER_TRANSPOSE,
     // push a projection to the children of a non semi/anti join
     // push all expressions to handle the time indicator correctly

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -204,17 +204,6 @@ object FlinkBatchRuleSets {
     CoreRules.AGGREGATE_VALUES
   )
 
-  /**
-   * RuleSet about project.
-   *
-   * <p>Note: [[CoreRules.PROJECT_FILTER_TRANSPOSE]] is the safe default kept here so it propagates
-   * into [[LOGICAL_OPT_RULES]] for the Volcano LOGICAL phase. In the HEP `PROJECT_REWRITE` phase,
-   * [[FlinkBatchProgram.buildProgram]] substitutes the configured variant from
-   * [[OptimizerConfigOptions.TABLE_OPTIMIZER_PROJECT_FILTER_TRANSPOSE_RULE]]. The aggressive
-   * `WHOLE_EXPRESSIONS` variant must NOT reach Volcano — it oscillates with
-   * [[FlinkFilterProjectTransposeRule]] when bloat protection is bypassed. See
-   * PROJECT_FILTER_TRANSPOSE_HANG.md.
-   */
   val PROJECT_RULES: RuleSet = RuleSets.ofList(
     // push a projection past a filter (safe default; HEP swaps in the configured variant)
     CoreRules.PROJECT_FILTER_TRANSPOSE,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -202,9 +202,19 @@ object FlinkStreamRuleSets {
     CoreRules.AGGREGATE_VALUES
   )
 
-  /** RuleSet about project */
+  /**
+   * RuleSet about project.
+   *
+   * <p>Note: [[CoreRules.PROJECT_FILTER_TRANSPOSE]] is the safe default kept here so it propagates
+   * into [[LOGICAL_OPT_RULES]] for the Volcano LOGICAL phase. In the HEP `PROJECT_REWRITE` phase,
+   * [[FlinkStreamProgram.buildProgram]] substitutes the configured variant from
+   * [[OptimizerConfigOptions.TABLE_OPTIMIZER_PROJECT_FILTER_TRANSPOSE_RULE]]. The aggressive
+   * `WHOLE_EXPRESSIONS` variant must NOT reach Volcano — it oscillates with
+   * [[FlinkFilterProjectTransposeRule]] when bloat protection is bypassed. See
+   * PROJECT_FILTER_TRANSPOSE_HANG.md.
+   */
   val PROJECT_RULES: RuleSet = RuleSets.ofList(
-    // push a projection past a filter
+    // push a projection past a filter (safe default; HEP swaps in the configured variant)
     CoreRules.PROJECT_FILTER_TRANSPOSE,
     // push a projection to the children of a non semi/anti join
     // push all expressions to handle the time indicator correctly

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -202,17 +202,6 @@ object FlinkStreamRuleSets {
     CoreRules.AGGREGATE_VALUES
   )
 
-  /**
-   * RuleSet about project.
-   *
-   * <p>Note: [[CoreRules.PROJECT_FILTER_TRANSPOSE]] is the safe default kept here so it propagates
-   * into [[LOGICAL_OPT_RULES]] for the Volcano LOGICAL phase. In the HEP `PROJECT_REWRITE` phase,
-   * [[FlinkStreamProgram.buildProgram]] substitutes the configured variant from
-   * [[OptimizerConfigOptions.TABLE_OPTIMIZER_PROJECT_FILTER_TRANSPOSE_RULE]]. The aggressive
-   * `WHOLE_EXPRESSIONS` variant must NOT reach Volcano — it oscillates with
-   * [[FlinkFilterProjectTransposeRule]] when bloat protection is bypassed. See
-   * PROJECT_FILTER_TRANSPOSE_HANG.md.
-   */
   val PROJECT_RULES: RuleSet = RuleSets.ofList(
     // push a projection past a filter (safe default; HEP swaps in the configured variant)
     CoreRules.PROJECT_FILTER_TRANSPOSE,


### PR DESCRIPTION
First try to get this rule configurable




TODO V
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
